### PR TITLE
Update context fail to allow custom exceptions

### DIFF
--- a/src/Context.php
+++ b/src/Context.php
@@ -59,17 +59,26 @@ class Context extends MutableTransformer
      * Marks the state of the interactor as failed, setting a sensible messaeg
      * to explain what went wrong.
      *
-     * @param string $message [optional]
+     * @param string|Exception $exception [optional]
      *
      * @return Interactor
      *
      * @throws Failure
      */
-    public function fail($message = null)
+    public function fail($exception = null)
     {
+        $message = null;
+
+        if( ! $exception instanceof \Exception) {
+            $message   = $exception;
+            $exception = new Failure($this, $message);
+        } else {
+            $message = $exception->getMessage();
+        }
+
         $this->status = new Error($this, $message);
 
-        throw new Failure($this, $message);
+        throw $exception;
     }
 
     /**


### PR DESCRIPTION
Sometimes you might want to throw a specific exception and to handle it properly  on you catch instead of having just a plain text message, so with this PR you can fail the context to be able to check of the context was success or not, but still being able to throw your own exception instead of always getting a Failure expception
